### PR TITLE
feat: ignore messages from bot owner

### DIFF
--- a/src/command-middleware.ts
+++ b/src/command-middleware.ts
@@ -1,6 +1,7 @@
 import { CommandMiddleware } from '@utils/middleware';
 import fs from 'fs/promises';
 import imageToSticker from './services/internal/image-to-sticker';
+import config from '@/env';
 
 const middleware = new CommandMiddleware()
 
@@ -10,6 +11,14 @@ const middleware = new CommandMiddleware()
  * Each middleware, return true if the execution should continue  
  * or false if the execution should stop.
  */
+
+// If the message is from the bot owner, ignore it completely
+middleware.use(async (_, message) => {
+    if (message.from === config.whatsappChatId) {
+        return false;
+    }
+    return true;
+})
 
 // Try to mark the message as seen.
 middleware.use(async (client, message) => {


### PR DESCRIPTION
### what this does

adds a middleware at the very start of the message pipeline that checks if `message.from` matches the `WHATSAPP_CHAT_ID` from your `.env` config. if it's the owner's number, the bot silently ignores the message — no seen mark, no response, nothing.

### why

so the bot doesn't reply to you when you test or message it. you can chat with your own bot without getting responses.

### how it fits

sits before all other middlewares (before mark-seen, before delay, before command routing) so it's the first gate.

### to use

make sure your `.env` has the right `WHATSAPP_CHAT_ID` set (format: `62xxxxx@c.us`).

---

_review at your leisure, genes_